### PR TITLE
Change 'unallowed' to 'disallowed'

### DIFF
--- a/src/lexer/token-errors.ts
+++ b/src/lexer/token-errors.ts
@@ -8,13 +8,13 @@ export class TokenizeError extends Error {
   }
 }
 
-function unallowedTokenMessage(unallowedToken: Token) {
-  return `${unallowedToken.literal} - at line ${unallowedToken.meta.ln}, column ${unallowedToken.meta.col} - is an unvalid character.`;
+function disallowedTokenMessage(disallowedToken: Token) {
+  return `${disallowedToken.literal} - at line ${disallowedToken.meta.ln}, column ${disallowedToken.meta.col} - is an unvalid character.`;
 }
 
-export function throwCollectedErrors(unallowedTokens: Token[]) {
-  const errorMessage = unallowedTokens.reduce(
-    (acc, v) => acc.concat(unallowedTokenMessage(v), '\n'.repeat(2)),
+export function throwCollectedErrors(disallowedTokens: Token[]) {
+  const errorMessage = disallowedTokens.reduce(
+    (acc, v) => acc.concat(disallowedTokenMessage(v), '\n'.repeat(2)),
     ''
   );
   throw new TokenizeError(fmtStr(errorMessage, 'red'));

--- a/src/lexer/token-helpers.ts
+++ b/src/lexer/token-helpers.ts
@@ -6,7 +6,7 @@ import {
   GREATER_THAN,
   GREATER_THAN_OR_EQUAL,
   IDENTIFIER,
-  UNALLOWED_CHARACTER,
+  DISALLOWED_CHARACTER,
   characterNames,
   BOOLEAN,
   NEW_LINE,
@@ -171,7 +171,7 @@ export function produceSingleSign(
   };
 }
 
-export function produceUnallowedCharacter(
+export function produceDisallowedCharacter(
   _input: string,
   _nextPosition: number,
   character: string,
@@ -179,7 +179,7 @@ export function produceUnallowedCharacter(
 ) {
   return {
     nextPosition: _nextPosition,
-    currentToken: newToken(UNALLOWED_CHARACTER, character, meta),
+    currentToken: newToken(DISALLOWED_CHARACTER, character, meta),
   };
 }
 

--- a/src/lexer/token-types.ts
+++ b/src/lexer/token-types.ts
@@ -35,7 +35,7 @@ export const BOOLEAN = 'Boolean';
 export const INTEGER = 'Integer';
 export const ASSIGN = '=';
 export const SEMICOLON = ';';
-export const UNALLOWED_CHARACTER = 'UNALLOWED_CHARACTER';
+export const DISALLOWED_CHARACTER = 'DISALLOWED_CHARACTER';
 export const GREATER_THAN = '>';
 export const LOWER_THAN = '<';
 export const GREATER_THAN_OR_EQUAL = '>=';

--- a/src/lexer/tokenize.ts
+++ b/src/lexer/tokenize.ts
@@ -4,7 +4,7 @@ import {
   isWhitespace,
   isDigit,
   isASCIIAlphabetic,
-  isUnallowedToken,
+  isDisallowedToken,
   isSingleSign,
   isComparisonOperator,
   isNUL,
@@ -15,7 +15,7 @@ import {
   produceNULToken,
   produceComparisionOperatorToken,
   produceIdentifier,
-  produceUnallowedCharacter,
+  produceDisallowedCharacter,
   produceNumber,
   produceSingleSign,
   readCharacter,
@@ -75,7 +75,7 @@ const tokenHandlers: TokenHandler[] = [
   [isASCIIAlphabetic, produceIdentifier],
   [isDigit, produceNumber],
   [isQuoteSign, produceString],
-  [defaultAlwaysTrue, produceUnallowedCharacter],
+  [defaultAlwaysTrue, produceDisallowedCharacter],
 ];
 
 export function peekCharacter(input: string, nextPosition: number) {
@@ -162,9 +162,9 @@ export function tokenize(input: string): Token[] {
     character,
     meta,
   });
-  if (tokens.some(isUnallowedToken)) {
-    const unallowedTokens = tokens.filter(isUnallowedToken);
-    throwCollectedErrors(unallowedTokens);
+  if (tokens.some(isDisallowedToken)) {
+    const disallowedTokens = tokens.filter(isDisallowedToken);
+    throwCollectedErrors(disallowedTokens);
   }
   return tokens;
 }

--- a/src/utils/predicates.ts
+++ b/src/utils/predicates.ts
@@ -9,7 +9,7 @@ import {
   BANG,
   AND_SIGN,
   OR_SIGN,
-  UNALLOWED_CHARACTER,
+  DISALLOWED_CHARACTER,
   ASSIGN,
   L_PAREN,
   R_PAREN,
@@ -65,8 +65,8 @@ export function isQuoteSign(character: string) {
   return character.toLowerCase() === '"';
 }
 
-export function isUnallowedToken(token: Token) {
-  return token.type === UNALLOWED_CHARACTER;
+export function isDisallowedToken(token: Token) {
+  return token.type === DISALLOWED_CHARACTER;
 }
 
 export function isEqual(currentCharacter: string, nextCharacter: string) {

--- a/tests/tokenize.spec.ts
+++ b/tests/tokenize.spec.ts
@@ -99,7 +99,7 @@ let numTwo =333;
       expect(tokens).to.deep.equal(res);
     });
 
-    it('Should throw on unallowed token', () => {
+    it('Should throw on disallowed token', () => {
       const code = `
 let num_1 = 333;
 let ?? = 2;


### PR DESCRIPTION
Just a little help from one English learner to another. 😉 

It's actually not that "unallowed" isn't a word; of course it is. (It's in my huge _Webster's Third New International Dictionary_, for one.) But in terms of word frequency, "disallowed" is the variant that get the most usage.