### PR TITLE
Change 'unvalid' to 'invalid'

### DIFF
--- a/src/lexer/token-errors.ts
+++ b/src/lexer/token-errors.ts
@@ -9,7 +9,7 @@ export class TokenizeError extends Error {
 }
 
 function unallowedTokenMessage(unallowedToken: Token) {
-  return `${unallowedToken.literal} - at line ${unallowedToken.meta.ln}, column ${unallowedToken.meta.col} - is an unvalid character.`;
+  return `${unallowedToken.literal} - at line ${unallowedToken.meta.ln}, column ${unallowedToken.meta.col} - is an invalid character.`;
 }
 
 export function throwCollectedErrors(unallowedTokens: Token[]) {

--- a/tests/tokenize.spec.ts
+++ b/tests/tokenize.spec.ts
@@ -104,11 +104,11 @@ let numTwo =333;
 let num_1 = 333;
 let ?? = 2;
 `;
-      const expectedErrorMessage = `_ - at line 2, column 8 - is an unvalid character.
+      const expectedErrorMessage = `_ - at line 2, column 8 - is an invalid character.
 
-? - at line 3, column 5 - is an unvalid character.
+? - at line 3, column 5 - is an invalid character.
 
-? - at line 3, column 6 - is an unvalid character.
+? - at line 3, column 6 - is an invalid character.
 
 `;
       expect(() => tokenize(code)).to.throw(expectedErrorMessage);


### PR DESCRIPTION
English has many ways to negate words. (dis-, de-, in-, un-, neg-, mal-) Must be related to the many languages it stole its words from.